### PR TITLE
Imported the missing android.view.WindowManager

### DIFF
--- a/app/src/main/java/com/codingwithmitch/googlemaps2018/ui/ChatroomActivity.java
+++ b/app/src/main/java/com/codingwithmitch/googlemaps2018/ui/ChatroomActivity.java
@@ -12,6 +12,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.EditText;
 
 import com.codingwithmitch.googlemaps2018.R;


### PR DESCRIPTION
When I was trying to build this project with Gradle 6.1.1 (Gradle plugin v4.0) I got an error saying the WindowManager is missing. So I added it. This error might be occurred due to the latest updates of Gradle, but not sure about it. Anyways, after importing WindowManager the error was gone and the project rendered perfect.